### PR TITLE
Added cleanup logic in encryptor refresher service

### DIFF
--- a/paig-server/backend/paig/api/shield/services/tenant_data_encryptor_service.py
+++ b/paig-server/backend/paig/api/shield/services/tenant_data_encryptor_service.py
@@ -136,6 +136,11 @@ class EncryptionKeyRefresher:
             logger.debug(f"{self.tenant_id} : EncryptionKeyRefresher::start() creating task")
             self.task = asyncio.create_task(self.async_run())
 
+    def cleanup(self):
+        logger.debug(f"==> {self.tenant_id} : EncryptionKeyRefresher::cleanup()")
+        self.exit_event.set()
+        logger.debug(f"<== {self.tenant_id} : EncryptionKeyRefresher::cleanup()")
+        
     def get_key_from_cache(self):
         logger.debug(f"==> {self.tenant_id} : EncryptionKeyRefresher::get_key_from_cache()")
         encryption_key_info_list = []


### PR DESCRIPTION
## Change Description

The missing cleanup method added with the logic to exit the async task 

## Issue reference

This PR fixes issue #77 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required