### PR TITLE
fix #102 paig_server install issue

### DIFF
--- a/paig-server/backend/requirements.txt
+++ b/paig-server/backend/requirements.txt
@@ -28,6 +28,7 @@ opentelemetry-exporter-otlp==1.24.0
 paig_common
 alt-profanity-check==1.5.0
 numpy==1.26.4
+scipy==1.14.1
 starlette-request-id==0.7.0
 httpx==0.27.0
 fasteners

--- a/paig-server/pyproject.toml
+++ b/paig-server/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "paig_common",
     "alt-profanity-check==1.5.0",
     "numpy==1.26.4",
+    "scipy==1.14.1",
     "starlette-request-id",
     "httpx",
     "fasteners",


### PR DESCRIPTION
## Change Description

Harded scipy==1.14.1 version (latest), without it pip is using older 1.9.1 version.
## Issue reference

This PR fixes issue #102 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required