### PR TITLE
Improve API Error Handling for Wrong API Endpoints

### DIFF
--- a/paig-server/backend/paig/server.py
+++ b/paig-server/backend/paig/server.py
@@ -23,6 +23,7 @@ import webbrowser
 import logging
 from fastapi.exceptions import RequestValidationError
 from fastapi.encoders import jsonable_encoder
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +102,16 @@ def init_listeners(app_: FastAPI) -> None:
             content={"error_code": 500, "success": False,
                      "message": "An unexpected error occurred. Please try again later."}
         )
+
+    @app_.exception_handler(StarletteHTTPException)
+    async def path_not_found_exception_handler(request: Request, exc: StarletteHTTPException):
+        if exc.status_code == 404:
+            return JSONResponse(content=jsonable_encoder({
+                    "error_code": 404,
+                    "success": False,
+                    "message": "Path Not Found",
+                    "path": request.url.path
+                }), status_code=status.HTTP_404_NOT_FOUND)
 
 
 def init_cache() -> None:

--- a/paig-server/backend/paig/tests/api/router/test_path_not_found.py
+++ b/paig-server/backend/paig/tests/api/router/test_path_not_found.py
@@ -1,0 +1,46 @@
+import pytest
+from fastapi import FastAPI
+from httpx import AsyncClient
+
+from core.security.authentication import get_auth_user
+
+user_services_base_route = "account-service/api"
+governance_services_base_route = "governance-service/api/ai"
+
+
+class TestPathNotFound:
+    def setup_method(self):
+        self.auth_user_obj = {
+            "id": 1,
+            "username": "test",
+            "roles": ["USER"]
+        }
+
+    def auth_user(self):
+        return self.auth_user_obj
+
+    @pytest.mark.asyncio
+    async def test_invalid_path_account_service_api(self, client: AsyncClient, app: FastAPI):
+        app.dependency_overrides[get_auth_user] = self.auth_user
+
+        response = await client.post(
+            f"{user_services_base_route}/invalid_path"
+        )
+
+        assert response.status_code == 404
+        assert response.json()['error_code'] == 404
+        assert response.json()['message'] == 'Path Not Found'
+        assert (response.json()['path'] == f"/{user_services_base_route}/invalid_path")
+
+    @pytest.mark.asyncio
+    async def test_invalid_path_governance_service_api(self, client: AsyncClient, app: FastAPI):
+        app.dependency_overrides[get_auth_user] = self.auth_user
+
+        response = await client.get(
+            f"{governance_services_base_route}/invalid_path"
+        )
+
+        assert response.status_code == 404
+        assert response.json()['error_code'] == 404
+        assert response.json()['message'] == 'Path Not Found'
+        assert (response.json()['path'] == f"/{governance_services_base_route}/invalid_path")


### PR DESCRIPTION
## Change Description

Added custom exception handler for 404 path not found error with details having error_code, message and path

## Issue reference

This PR fixes issue #84  

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required