### PR TITLE
Added check for explicit_application_access_allowed in async base paig authorizer

### DIFF
--- a/paig-authorizer-core/paig_authorizer_core/async_base_paig_authorizer.py
+++ b/paig-authorizer-core/paig_authorizer_core/async_base_paig_authorizer.py
@@ -196,7 +196,7 @@ class AsyncBasePAIGAuthorizer(AsyncPAIGAuthorizer, ABC):
         if check_explicit_application_access(request, app_config, user_groups, "denied"):
             audit_policy_ids_set.add(app_config.id)
             return create_authorize_response(request, application_name, authorized, masked_traits,
-                                             list(audit_policy_ids_set))
+                                             list(audit_policy_ids_set), reason="Explicit deny access to Application")
 
         # Step 4: Check for explicit allow in application config
         explicit_application_access_allowed = check_explicit_application_access(
@@ -205,6 +205,11 @@ class AsyncBasePAIGAuthorizer(AsyncPAIGAuthorizer, ABC):
             user_groups,
             "allowed"
         )
+
+        if not explicit_application_access_allowed:
+            audit_policy_ids_set.add(app_config.id)
+            return create_authorize_response(request, application_name, authorized, masked_traits,
+                                             list(audit_policy_ids_set), reason="No Access to Application")
 
         # Step 4a: Retrieve application policies matching request traits, user, groups, and request type
         application_policies = await self.get_application_policies(request.application_key, request.traits,
@@ -229,6 +234,7 @@ class AsyncBasePAIGAuthorizer(AsyncPAIGAuthorizer, ABC):
         else:
             # Step 4e: No matching policies, default to authorized with no masked traits
             authorized = True if explicit_application_access_allowed else False
+            audit_policy_ids_set.add(app_config.id)
             return create_authorize_response(request, application_name, authorized, masked_traits,
                                              list(audit_policy_ids_set))
 

--- a/paig-authorizer-core/tests/async_test_base_paig_authorizer.py
+++ b/paig-authorizer-core/tests/async_test_base_paig_authorizer.py
@@ -169,3 +169,62 @@ async def test_authorize_explicit_deny(authz_request, authorizer: AsyncBasePAIGA
     assert response.authorized is False
     assert response.status_code == 403
     assert 2 in response.paig_policy_ids
+
+
+@pytest.mark.asyncio
+async def test_authorize_application_config_explicit_user_allow(authz_request, authorizer: AsyncBasePAIGAuthorizer):
+    app_config = AIApplicationConfigData(id=1, allowed_users=["test_user"])
+    authorizer.get_application_config = AsyncMock(return_value=app_config)
+    authorizer.get_application_policies = AsyncMock(return_value=[])
+    response = await authorizer.authorize(authz_request)
+
+    assert response.authorized is True
+    assert response.status_code == 200
+    assert 1 in response.paig_policy_ids
+
+@pytest.mark.asyncio
+async def test_authorize_application_config_explicit_group_allow(authz_request, authorizer: AsyncBasePAIGAuthorizer):
+    app_config = AIApplicationConfigData(id=1, allowed_groups=["public"])
+    authorizer.get_application_config = AsyncMock(return_value=app_config)
+    authorizer.get_application_policies = AsyncMock(return_value=[])
+    response = await authorizer.authorize(authz_request)
+
+    assert response.authorized is True
+    assert response.status_code == 200
+    assert 1 in response.paig_policy_ids
+
+@pytest.mark.asyncio
+async def test_authorize_application_config_explicit_user_deny(authz_request, authorizer: AsyncBasePAIGAuthorizer):
+    app_config = AIApplicationConfigData(id=1, denied_users=["test_user"])
+    authorizer.get_application_config = AsyncMock(return_value=app_config)
+    authorizer.get_application_policies = AsyncMock(return_value=[])
+    response = await authorizer.authorize(authz_request)
+
+    assert response.authorized is False
+    assert response.status_code == 403
+    assert 1 in response.paig_policy_ids
+    assert response.reason == "Explicit deny access to Application"
+
+@pytest.mark.asyncio
+async def test_authorize_application_config_explicit_group_deny(authz_request, authorizer: AsyncBasePAIGAuthorizer):
+    app_config = AIApplicationConfigData(id=1, denied_groups=["public"])
+    authorizer.get_application_config = AsyncMock(return_value=app_config)
+    authorizer.get_application_policies = AsyncMock(return_value=[])
+    response = await authorizer.authorize(authz_request)
+
+    assert response.authorized is False
+    assert response.status_code == 403
+    assert 1 in response.paig_policy_ids
+    assert response.reason == "Explicit deny access to Application"
+
+@pytest.mark.asyncio
+async def test_authorize_application_config_no_access(authz_request, authorizer: AsyncBasePAIGAuthorizer):
+    app_config = AIApplicationConfigData(id=1)
+    authorizer.get_application_config = AsyncMock(return_value=app_config)
+    authorizer.get_application_policies = AsyncMock(return_value=[])
+    response = await authorizer.authorize(authz_request)
+
+    assert response.authorized is False
+    assert response.status_code == 403
+    assert 1 in response.paig_policy_ids
+    assert response.reason == "No Access to Application"

--- a/paig-authorizer-core/tests/test_base_paig_authorizer.py
+++ b/paig-authorizer-core/tests/test_base_paig_authorizer.py
@@ -163,3 +163,61 @@ def test_authorize_explicit_deny(authz_request, authorizer: BasePAIGAuthorizer):
     assert response.authorized is False
     assert response.status_code == 403
     assert 2 in response.paig_policy_ids
+
+
+def test_authorize_application_config_explicit_user_allow(authz_request, authorizer: BasePAIGAuthorizer):
+    app_config = AIApplicationConfigData(id=1, allowed_users=["test_user"])
+    authorizer.get_application_config = Mock(return_value=app_config)
+    authorizer.get_application_policies = Mock(return_value=[])
+    response = authorizer.authorize(authz_request)
+
+    assert response.authorized is True
+    assert response.status_code == 200
+    assert 1 in response.paig_policy_ids
+
+
+def test_authorize_application_config_explicit_group_allow(authz_request, authorizer: BasePAIGAuthorizer):
+    app_config = AIApplicationConfigData(id=1, allowed_groups=["public"])
+    authorizer.get_application_config = Mock(return_value=app_config)
+    authorizer.get_application_policies = Mock(return_value=[])
+    response = authorizer.authorize(authz_request)
+
+    assert response.authorized is True
+    assert response.status_code == 200
+    assert 1 in response.paig_policy_ids
+
+
+def test_authorize_application_config_explicit_user_deny(authz_request, authorizer: BasePAIGAuthorizer):
+    app_config = AIApplicationConfigData(id=1, denied_users=["test_user"])
+    authorizer.get_application_config = Mock(return_value=app_config)
+    authorizer.get_application_policies = Mock(return_value=[])
+    response = authorizer.authorize(authz_request)
+
+    assert response.authorized is False
+    assert response.status_code == 403
+    assert 1 in response.paig_policy_ids
+    assert response.reason == "Explicit deny access to Application"
+
+
+def test_authorize_application_config_explicit_group_deny(authz_request, authorizer: BasePAIGAuthorizer):
+    app_config = AIApplicationConfigData(id=1, denied_groups=["public"])
+    authorizer.get_application_config = Mock(return_value=app_config)
+    authorizer.get_application_policies = Mock(return_value=[])
+    response = authorizer.authorize(authz_request)
+
+    assert response.authorized is False
+    assert response.status_code == 403
+    assert 1 in response.paig_policy_ids
+    assert response.reason == "Explicit deny access to Application"
+
+
+def test_authorize_application_config_no_access(authz_request, authorizer: BasePAIGAuthorizer):
+    app_config = AIApplicationConfigData(id=1)
+    authorizer.get_application_config = Mock(return_value=app_config)
+    authorizer.get_application_policies = Mock(return_value=[])
+    response = authorizer.authorize(authz_request)
+
+    assert response.authorized is False
+    assert response.status_code == 403
+    assert 1 in response.paig_policy_ids
+    assert response.reason == "No Access to Application"

--- a/paig-server/backend/paig/api/shield/client/local_authz_service_client.py
+++ b/paig-server/backend/paig/api/shield/client/local_authz_service_client.py
@@ -61,8 +61,7 @@ class LocalAuthzClient(IAuthzClient):
         """
         tranformed_authz_request = self.transform_authz_request(authz_service_request)
         authz_response = await self.paig_authorizer.authorize(tranformed_authz_request)
-        if not authz_response.reason:
-            logger.debug(f"Reason: {authz_response.reason}")
+        logger.debug(f"Reason: {authz_response.reason}")
         return self.transform_authz_response(authz_response)
 
     async def post_authorize_vectordb(self, vectordb_auth_req: AuthorizeVectorDBRequest, tenant_id):


### PR DESCRIPTION

## Change Description

Following are the changes present in the PR:

1. For GenAI Applications, the user and groups level access controls are enforced
2. Set the paig policy id if the access was granted by the application (or application config).
3. Add reason for debugging purpose for both check_explicit_application_access and explicit_application_access_allowed (internal)
4. Removed if condition from the printing the debug logs for debugging

## Issue reference

This PR fixes issue #108 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required