### PR TITLE
workflows updated to install paig-common before CI #143

### DIFF
--- a/.github/workflows/paig-client-ci.yml
+++ b/.github/workflows/paig-client-ci.yml
@@ -9,6 +9,7 @@ on:
     branches: [ "main" ]
     paths:
       - 'paig-client/**'
+  workflow_dispatch: # Allows manual trigger
 
 permissions:
   contents: read
@@ -24,11 +25,25 @@ jobs:
       with:
         python-version: "3.10"
 
-    - name: Install dependencies
+    - name: Prepare venv
       run: |
         python3 -m pip install virtualenv
-        virtualenv -p python3 venv && . venv/bin/activate
+        virtualenv -p python3 venv
+        . venv/bin/activate
         pip install twine build pytest pytest-cov
+
+    - name: Build and Install paig-common wheel
+      run: |
+        . venv/bin/activate
+        cd paig-common
+        python3 -m build -w
+        pip install dist/*.whl
+        cd ..
+
+
+    - name: Install Paig-Client dependencies
+      run: |
+        . venv/bin/activate
         pip install -r paig-client/requirements.txt
 
     - name: Test with pytest

--- a/.github/workflows/paig-server-ci.yml
+++ b/.github/workflows/paig-server-ci.yml
@@ -9,6 +9,7 @@ on:
     branches: [ "main" ]
     paths:
       - 'paig-server/**'
+  workflow_dispatch: # Allows manual trigger
 
 permissions:
   contents: read
@@ -24,11 +25,24 @@ jobs:
       with:
         python-version: "3.10"
 
-    - name: Install dependencies
+    - name: Prepare venv
       run: |
         python3 -m pip install virtualenv
-        virtualenv -p python3 venv && . venv/bin/activate
+        virtualenv -p python3 venv
+        . venv/bin/activate
         pip install twine build pytest pytest-cov
+        
+    - name: Build and Install paig-common wheel
+      run: |
+        . venv/bin/activate
+        cd paig-common
+        python3 -m build -w
+        pip install dist/*.whl
+        cd ..
+
+    - name: Install PAIG-Server dependencies
+      run: |
+        . venv/bin/activate
         pip install -r paig-server/backend/requirements.txt
 
     - name: Test with pytest


### PR DESCRIPTION
## Change Description

Describe your changes

Workflow should build and install local paig-common for paig-server and paig-client
This PR fixes issue #143

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required