### PR TITLE
dashboard-graph-fix: Correct application count display in sensitive data access dashboard graph

### DIFF
--- a/paig-server/frontend/webapp/app/components/dashboard/v_dashboard.jsx
+++ b/paig-server/frontend/webapp/app/components/dashboard/v_dashboard.jsx
@@ -1,5 +1,6 @@
 import React, { Component, Fragment } from "react";
 import { observer } from "mobx-react";
+import { maxBy } from 'lodash';
 
 import { Box, Grid, Paper, Typography } from "@material-ui/core";
 
@@ -66,7 +67,8 @@ const VSensitiveDataAccess = observer(({data}) => {
 
   let models = f.models(data);
   let length = models.length;
-  let maxQuery = length > 0 ? models[0].queries || 0 : 0;
+  // Find the maximum queries value across all models
+  let maxQuery = maxBy(models, 'queries')?.queries || 0;
 
   if (length) {
     const middleIndex = Math.ceil(length / 2);


### PR DESCRIPTION
## Change Description

Refactor: Use lodash `maxBy` for calculating max query value across models

- Addressed issue where the graph failed to display all applications correctly
- Replaced conditional check on the first model’s queries with `maxBy` function
- New approach finds the maximum `queries` value across all models, improving accuracy and readability
- Ensures `maxQuery` reflects the highest query count in any model

## Issue reference

This PR fixes issue #137 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required