### PR TITLE
Paig evaluation temporary output_path issue fix

### DIFF
--- a/paig-evaluation/paig_evaluation/command_utils.py
+++ b/paig-evaluation/paig_evaluation/command_utils.py
@@ -112,11 +112,11 @@ def wait_for_process_complete(process: subprocess.Popen, verbose: bool = False):
         if status == 0:
             break
         elif status == -1:
-            break
-        else:
             error_message = process.stderr.read()
             if error_message:
                 logger.error(error_message)
+            break
+        else:
             if verbose:
                 stdout_line = process.stdout.readline()
                 if stdout_line:

--- a/paig-evaluation/paig_evaluation/promptfoo_utils.py
+++ b/paig-evaluation/paig_evaluation/promptfoo_utils.py
@@ -384,6 +384,8 @@ def generate_promptfoo_redteam_config(application_config: dict, plugins: List[st
         dict: Promptfoo redteam configuration.
     """
     generated_config = None
+    promptfoo_config_file_name = None
+    output_path = None
     try:
         paig_evaluation_app_id = application_config.get("paig_eval_id")
         application_name = application_config.get("name", "PAIG Evaluation Application")
@@ -403,10 +405,10 @@ def generate_promptfoo_redteam_config(application_config: dict, plugins: List[st
         }
 
         promptfoo_config_file_name = f"tmp_{paig_evaluation_app_id}_promptfoo_redteam_config.yaml"
+        output_path = f"tmp_{paig_evaluation_app_id}_promptfoo_generated_prompts.yaml"
         write_yaml_file(promptfoo_config_file_name, readteam_config)
 
         # Generate prompts for redteam
-        output_path = f"tmp_{paig_evaluation_app_id}_promptfoo_generated_prompts.yaml"
         command = f"promptfoo redteam generate --max-concurrency 5 --config {promptfoo_config_file_name} --output {output_path}"
 
         process = run_command_in_background(command)
@@ -420,9 +422,9 @@ def generate_promptfoo_redteam_config(application_config: dict, plugins: List[st
     except Exception as e:
         logger.error(f"Error while generating prompts: {e}")
     finally:
-        if os.path.exists(promptfoo_config_file_name):
+        if promptfoo_config_file_name and os.path.exists(promptfoo_config_file_name):
             os.remove(promptfoo_config_file_name)
-        if os.path.exists(output_path):
+        if output_path and os.path.exists(output_path):
             os.remove(output_path)
         return generated_config
 
@@ -444,9 +446,9 @@ def run_promptfoo_redteam_evaluation(paig_eval_id: str, promptfoo_redteam_config
 
     # Create updated promptfoo redteam configuration
     evaluation_report = None
+    promptfoo_generated_prompts_file_name = f"tmp_{paig_eval_id}_promptfoo_generated_prompts.yaml"
+    output_path = f"tmp_{paig_eval_id}_promptfoo_evaluation_report.json"
     try:
-        promptfoo_generated_prompts_file_name = f"tmp_{paig_eval_id}_promptfoo_generated_prompts.yaml"
-
         base_tests = base_prompts.get("tests") if base_prompts else []
         custom_tests = custom_prompts.get("tests") if custom_prompts else []
         promptfoo_redteam_config["tests"] = base_tests + custom_tests + promptfoo_redteam_config["tests"]
@@ -454,7 +456,6 @@ def run_promptfoo_redteam_evaluation(paig_eval_id: str, promptfoo_redteam_config
         write_yaml_file(promptfoo_generated_prompts_file_name, promptfoo_redteam_config)
 
         # Run promptfoo redteam evaluation
-        output_path = f"tmp_{paig_eval_id}_promptfoo_evaluation_report.json"
         command = f"promptfoo redteam eval --config {promptfoo_generated_prompts_file_name} --output {output_path}"
 
         process = run_command_in_background(command)

--- a/paig-evaluation/paig_evaluation/promptfoo_utils.py
+++ b/paig-evaluation/paig_evaluation/promptfoo_utils.py
@@ -385,7 +385,7 @@ def generate_promptfoo_redteam_config(application_config: dict, plugins: List[st
     """
     generated_config = None
     promptfoo_config_file_name = None
-    output_path = None
+    output_file_name = None
     try:
         paig_evaluation_app_id = application_config.get("paig_eval_id")
         application_name = application_config.get("name", "PAIG Evaluation Application")
@@ -405,27 +405,27 @@ def generate_promptfoo_redteam_config(application_config: dict, plugins: List[st
         }
 
         promptfoo_config_file_name = f"tmp_{paig_evaluation_app_id}_promptfoo_redteam_config.yaml"
-        output_path = f"tmp_{paig_evaluation_app_id}_promptfoo_generated_prompts.yaml"
+        output_file_name = f"tmp_{paig_evaluation_app_id}_promptfoo_generated_prompts.yaml"
         write_yaml_file(promptfoo_config_file_name, readteam_config)
 
         # Generate prompts for redteam
-        command = f"promptfoo redteam generate --max-concurrency 5 --config {promptfoo_config_file_name} --output {output_path}"
+        command = f"promptfoo redteam generate --max-concurrency 5 --config {promptfoo_config_file_name} --output {output_file_name}"
 
         process = run_command_in_background(command)
         wait_for_process_complete(process, verbose=verbose)
 
-        if not os.path.exists(output_path):
+        if not os.path.exists(output_file_name):
             error_message = f"Prompts generation failed for given config with ID {paig_evaluation_app_id}."
             raise RuntimeError(error_message)
         # Read generated prompts
-        generated_config = read_yaml_file(output_path)
+        generated_config = read_yaml_file(output_file_name)
     except Exception as e:
         logger.error(f"Error while generating prompts: {e}")
     finally:
         if promptfoo_config_file_name and os.path.exists(promptfoo_config_file_name):
             os.remove(promptfoo_config_file_name)
-        if output_path and os.path.exists(output_path):
-            os.remove(output_path)
+        if output_file_name and os.path.exists(output_file_name):
+            os.remove(output_file_name)
         return generated_config
 
 
@@ -447,7 +447,7 @@ def run_promptfoo_redteam_evaluation(paig_eval_id: str, promptfoo_redteam_config
     # Create updated promptfoo redteam configuration
     evaluation_report = None
     promptfoo_generated_prompts_file_name = f"tmp_{paig_eval_id}_promptfoo_generated_prompts.yaml"
-    output_path = f"tmp_{paig_eval_id}_promptfoo_evaluation_report.json"
+    output_file_name = f"tmp_{paig_eval_id}_promptfoo_evaluation_report.json"
     try:
         base_tests = base_prompts.get("tests") if base_prompts else []
         custom_tests = custom_prompts.get("tests") if custom_prompts else []
@@ -456,23 +456,23 @@ def run_promptfoo_redteam_evaluation(paig_eval_id: str, promptfoo_redteam_config
         write_yaml_file(promptfoo_generated_prompts_file_name, promptfoo_redteam_config)
 
         # Run promptfoo redteam evaluation
-        command = f"promptfoo redteam eval --config {promptfoo_generated_prompts_file_name} --output {output_path}"
+        command = f"promptfoo redteam eval --config {promptfoo_generated_prompts_file_name} --output {output_file_name}"
 
         process = run_command_in_background(command)
         wait_for_process_complete(process, verbose=verbose)
 
-        if not os.path.exists(output_path):
+        if not os.path.exists(output_file_name):
             error_message = f"Evaluation failed for given config with ID {paig_eval_id}."
             raise RuntimeError(error_message)
 
         # Read evaluation report
-        evaluation_report = read_json_file(output_path)
+        evaluation_report = read_json_file(output_file_name)
     except Exception as e:
         logger.error(f"Error while running evaluation process: {e}")
     finally:
         if os.path.exists(promptfoo_generated_prompts_file_name):
             os.remove(promptfoo_generated_prompts_file_name)
-        if os.path.exists(output_path):
-            os.remove(output_path)
+        if os.path.exists(output_file_name):
+            os.remove(output_file_name)
         return evaluation_report
 


### PR DESCRIPTION
## Change Description
Issue in evaluation error is `local variable 'output_path' referenced before assignment`
Paig evaluation temporary output_path issue fix in generate prompts and evalution api.
Logging error logs on proccess excetion failed.

## Issue reference

This PR fixes issue #182

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required