### PR TITLE
Securechat removed uvloop dependency

### DIFF
--- a/paig-securechat/web-server/requirements.txt
+++ b/paig-securechat/web-server/requirements.txt
@@ -105,7 +105,6 @@ typing-inspect==0.9.0
 unstructured==0.10.19
 urllib3
 uvicorn==0.23.2
-uvloop==0.17.0
 watchfiles==0.20.0
 websockets==11.0.3
 yarl==1.9.2


### PR DESCRIPTION
## Change Description

Securechat removed uvloop dependency, which is option and os dependent.

## Issue reference

This PR fixes issue #

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required