### PR TITLE
Paig server mysql issue resolve for evaluation tables

### DIFF
--- a/paig-server/backend/paig/alembic_db/versions/701ddf55a1b4_added_evaluation_tables.py
+++ b/paig-server/backend/paig/alembic_db/versions/701ddf55a1b4_added_evaluation_tables.py
@@ -76,9 +76,9 @@ def upgrade() -> None:
     )
     op.create_index(op.f('ix_eval_config_history_id'), 'eval_config_history', ['id'], unique=False)
     op.create_table('eval_result_prompt',
-    sa.Column('eval_run_id', sa.String(length=255), nullable=False),
+    sa.Column('eval_run_id', sa.Integer(), nullable=False),
     sa.Column('eval_id', sa.String(length=255), nullable=False),
-    sa.Column('prompt_uuid', sa.String(length=255), nullable=False),
+    sa.Column('prompt_uuid', sa.String(length=255), nullable=False, unique=True),
     sa.Column('prompt', sa.Text(), nullable=False),
     sa.Column('id', sa.Integer(), autoincrement=True, nullable=False),
     sa.Column('create_time', sa.DateTime(), nullable=True),
@@ -102,7 +102,7 @@ def upgrade() -> None:
     )
     op.create_index(op.f('ix_eval_target_id'), 'eval_target', ['id'], unique=False)
     op.create_table('eval_result_response',
-    sa.Column('eval_run_id', sa.String(length=255), nullable=False),
+    sa.Column('eval_run_id', sa.Integer(), nullable=False),
     sa.Column('eval_result_prompt_uuid', sa.String(length=255), nullable=False),
     sa.Column('eval_id', sa.String(length=255), nullable=False),
     sa.Column('response', sa.Text(), nullable=True),

--- a/paig-server/backend/paig/api/evaluation/database/db_models/eval_model.py
+++ b/paig-server/backend/paig/api/evaluation/database/db_models/eval_model.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, String, ForeignKey, Text
+from sqlalchemy import Column, String, ForeignKey, Text, Integer
 from sqlalchemy.orm import relationship
 from api.evaluation.database.db_models.base_model import CommonBase
 
@@ -54,9 +54,9 @@ class EvaluationResultPromptsModel(CommonBase):
     prompt: The prompt text
     """
     __tablename__ = "eval_result_prompt"
-    eval_run_id = Column(String(255), ForeignKey('eval_run.id', ondelete="CASCADE"), nullable=False)
+    eval_run_id = Column(Integer, ForeignKey('eval_run.id', ondelete="CASCADE"), nullable=False)
     eval_id = Column(String(255), nullable=False)
-    prompt_uuid = Column(String(255), nullable=False)
+    prompt_uuid = Column(String(255), nullable=False, unique=True)
     prompt = Column(Text(), nullable=False)
 
     # One-to-Many relationship with EvaluationResultResponseModel
@@ -79,7 +79,7 @@ class EvaluationResultResponseModel(CommonBase):
     category: The category ran for against the prompt
     """
     __tablename__ = "eval_result_response"
-    eval_run_id = Column(String(255), ForeignKey('eval_run.id', ondelete="CASCADE"), nullable=False)
+    eval_run_id = Column(Integer, ForeignKey('eval_run.id', ondelete="CASCADE"), nullable=False)
     eval_result_prompt_uuid = Column(String(255), ForeignKey('eval_result_prompt.prompt_uuid'), nullable=False)
     eval_id = Column(String(255), nullable=False)
     response = Column(Text(), nullable=True)


### PR DESCRIPTION
## Change Description

MySQL compatibility added for eval tables

## Issue reference

This PR fixes issue #168 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required