### PR TITLE
Show specific denial reason from Shield server in SecureChat

### DIFF
--- a/paig-securechat/web-server/src/paig_securechat/configs/default_config.yaml
+++ b/paig-securechat/web-server/src/paig_securechat/configs/default_config.yaml
@@ -2,6 +2,7 @@
 ask_prompt_suffix: null
 client_error_msg: "[ERROR] Oops! Something went wrong. Our server encountered an unexpected error. Please try again later."
 shield_access_denied_msg: "Access Denied. You are not authorized to access this resource."
+show_shield_access_control_message: True
 
 openai:
     key_file: "custom-configs/openai.key"

--- a/paig-securechat/web-server/src/paig_securechat/configs/standalone_config.yaml
+++ b/paig-securechat/web-server/src/paig_securechat/configs/standalone_config.yaml
@@ -2,6 +2,7 @@
 ask_prompt_suffix: null
 client_error_msg: "[ERROR] Oops! Something went wrong. Our server encountered an unexpected error. Please try again later."
 shield_access_denied_msg: "Access Denied. You are not authorized to access this resource."
+show_shield_access_control_message: True
 
 openai:
     key_file: "custom-configs/openai.key"

--- a/paig-securechat/web-server/src/paig_securechat/services/langchain_service_intf.py
+++ b/paig-securechat/web-server/src/paig_securechat/services/langchain_service_intf.py
@@ -134,10 +134,13 @@ class LangChainServiceIntf:
         except paig_client.exception.AccessControlException as e:
             logger.exception(f"Access Denied, message: {e}")
             if self.show_shield_access_control_message:
-                error_message = re.sub(r"ERROR:\s*PAIG-\d{6}:\s*", "", str(e))
-                return error_message, None
+                return LangChainServiceIntf.remove_error_code(str(e)), None
             return self.shield_access_denied_msg, None
         except Exception as ex:
             logging.exception(
                 f"Exception occurred when asking auth_service to execute_prompt, question= {prompt} with error :: {ex}")
             return self.client_error_msg, None
+
+    @staticmethod
+    def remove_error_code(error_message):
+        return re.sub(r"ERROR:\s*PAIG-\d{6}:\s*", "", error_message)

--- a/paig-securechat/web-server/src/paig_securechat/services/langchain_service_intf.py
+++ b/paig-securechat/web-server/src/paig_securechat/services/langchain_service_intf.py
@@ -32,7 +32,6 @@ class LangChainServiceIntf:
         self.client_error_msg: str = self.config.get("client_error_msg")
         self.shield_access_denied_msg: str = self.config.get("shield_access_denied_msg")
         self.show_shield_access_control_message: bool = self.config.get("show_shield_access_control_message", "true") in ["true", "True", True]
-        logger.info(f"show_shield_access_control_message :: {self.show_shield_access_control_message}")
         self.disable_conversation_chain = ai_application_conf[self.ai_application_name].get(
             "disable_conversation_chain", False)
         self.response_if_no_docs_found = ai_application_conf.get("response_if_no_docs_found", None)
@@ -134,11 +133,8 @@ class LangChainServiceIntf:
 
         except paig_client.exception.AccessControlException as e:
             logger.exception(f"Access Denied, message: {e}")
-            logger.info(f"show_shield_access_control_message :: {self.show_shield_access_control_message}")
             if self.show_shield_access_control_message:
-                logger.info("error message before :: " + str(e))
                 error_message = re.sub(r"ERROR:\s*PAIG-\d{6}:\s*", "", str(e))
-                logger.info("error message after :: " + error_message)
                 return error_message, None
             return self.shield_access_denied_msg, None
         except Exception as ex:

--- a/paig-securechat/web-server/src/paig_securechat/tests/services/test_langchain_service_intf.py
+++ b/paig-securechat/web-server/src/paig_securechat/tests/services/test_langchain_service_intf.py
@@ -1,0 +1,15 @@
+import pytest
+
+from services.langchain_service_intf import LangChainServiceIntf
+
+
+@pytest.mark.parametrize("input_message, expected_output", [
+    ("ERROR: PAIG-123456: Some error occurred", "Some error occurred"),
+    ("ERROR: PAIG-987654: Another error happened", "Another error happened"),
+    ("Some message without error code", "Some message without error code"),
+    ("ERROR: PAIG-111111: ERROR: PAIG-222222: Chained errors", "Chained errors"),
+    ("ERROR:    PAIG-333333:   Extra spaces handled", "Extra spaces handled"),
+    ("", ""),
+])
+def test_remove_error_code(input_message, expected_output):
+    assert LangChainServiceIntf.remove_error_code(input_message) == expected_output


### PR DESCRIPTION
## Change Description
This update enhances SecureChat by allowing users to see the exact denial reason provided by the Shield server. A new configurable flag, **`show_shield_access_control_message`**, is introduced:  

- **When set to `true` (default)** → Displays the exact denial message from the Shield server.  
- **When set to `false`** → Falls back to the predefined message from the config file (current behavior).  

Additionally, to improve message clarity, error code **400004** is removed using a regex-based replacement.

## Issue reference

This PR fixes issue #279

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required