### PR TITLE
Added fix for the Sensitive Data Filter response message failure when tag is in REDACT with denied regex

### DIFF
--- a/paig-server/backend/paig/api/shield/services/auth_service.py
+++ b/paig-server/backend/paig/api/shield/services/auth_service.py
@@ -540,6 +540,7 @@ class AuthService:
                                                                             analyzer_result_map, auth_req, False,
                                                                             masked_traits)
 
+            authz_service_res.masked_traits.update(masked_traits)
             if Guardrail.BLOCKED.value in access_control_traits:
                 authz_service_res.authorized = is_allowed = False
                 authz_service_res.masked_traits = {}
@@ -547,7 +548,6 @@ class AuthService:
 
                 logger.debug(
                     f"Non Authz scanners blocked the request with all tags: {all_result_traits} and actions: {access_control_traits}")
-            authz_service_res.masked_traits.update(masked_traits)
             auth_req.context.pop("guardrail_info")
             auth_req.context.pop("pii_traits")
         return is_allowed, non_authz_scan_timings_per_message


### PR DESCRIPTION
…er with regex

## Change Description

Fixed an issue where the Sensitive Data Filter response message failed when tag was in Redact mode with a denied regex. This update ensures that the filter correctly handles responses containing template msg for the denied regex pattern.

## Issue reference

This PR fixes issue #283 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required