### PR TITLE
fix ai app association missing on guardrail save

### DIFF
--- a/paig-server/automation/cypress/e2e/guardrails/paig_guardrail_form_test.cy.js
+++ b/paig-server/automation/cypress/e2e/guardrails/paig_guardrail_form_test.cy.js
@@ -317,6 +317,9 @@ describe('Guardrail Form PAIG provider', () => {
             cy.get('[data-testid="snackbar"]').should('contain', 'created successfully');
             cy.wait(5000);
 
+            //check guardrail url
+            cy.url().should('match', /\/guardrails\/create\/\d+/);
+
             cy.get('[data-testid="test-text"]').type('Test Guardrail Text');
             cy.get('[data-testid="test-guardrail"]').should('be.visible').and('contain', 'TEST INPUT').click();
 
@@ -400,7 +403,6 @@ describe('Guardrail Form PAIG provider', () => {
         cy.url().should('match', /\/guardrails\/edit\/\d+/);
 
         cy.wait(5000);
-        cy.get('[data-testid="step-0"]').click();
 
         cy.get('[data-testid="basic-form"]').within(() => {
             cy.get('[data-testid="name"] input').should('be.disabled');

--- a/paig-server/frontend/webapp/app/components/guardrail/forms/guardrail_form_util.js
+++ b/paig-server/frontend/webapp/app/components/guardrail/forms/guardrail_form_util.js
@@ -34,7 +34,7 @@ class GuardrailFormUtil {
 	    this.apps = apps;
 	}
 	getApps() {
-	    return this.apps || [];
+	    return this.apps;
 	}
 
 	getSaveFormData () {

--- a/paig-server/frontend/webapp/app/routers/routes.jsx
+++ b/paig-server/frontend/webapp/app/routers/routes.jsx
@@ -72,6 +72,7 @@ const Routes = () => (
         <Route path="/vector_db/:id" name="Update Vector DB" component={Authorization(CVectorDBMain, [UI_CONSTANTS.PAIG_NAVIGATOR, UI_CONSTANTS.VECTOR_DB])} />
         <Route path="/vector_db" name="Vector DB" component={Authorization(CVectorDB, [UI_CONSTANTS.PAIG_NAVIGATOR, UI_CONSTANTS.VECTOR_DB])} />
 
+        <Route path="/guardrails/create/:newId" name="Create Guardrail" component={Authorization(CGuardrailForm, [UI_CONSTANTS.PAIG_GUARD, UI_CONSTANTS.GUARDRAILS])} />
         <Route path="/guardrails/create" name="Create Guardrail" component={Authorization(CGuardrailForm, [UI_CONSTANTS.PAIG_GUARD, UI_CONSTANTS.GUARDRAILS])} />
         <Route path="/guardrails/edit/:id" name="Update Guardrail" component={Authorization(CGuardrailForm, [UI_CONSTANTS.PAIG_GUARD, UI_CONSTANTS.GUARDRAILS])} />
         <Route path="/guardrails" name="Guardrails" component={Authorization(CGuardrailListing, [UI_CONSTANTS.PAIG_GUARD, UI_CONSTANTS.GUARDRAILS])} />


### PR DESCRIPTION
## Change Description
1. Resolve the bug on the edit guardrail screen where the AI app association is lost upon updating and saving.
2. Modified the edit guardrail action to redirect to the first page of the guardrail configuration instead of the test input screen.

Describe your changes

## Issue reference

This PR fixes issue #301 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required