### PR TITLE
Added guardrail_name to the request context to enhance audit filtering

### DIFF
--- a/paig-server/backend/paig/api/shield/services/auth_service.py
+++ b/paig-server/backend/paig/api/shield/services/auth_service.py
@@ -535,6 +535,7 @@ class AuthService:
             await self.tenant_data_encryptor_service.decrypt_guardrail_connection_details(auth_req.tenant_id, guardrail_info.get("guardrail_connection_details", {}))
             auth_req.context.update({"guardrail_info": guardrail_info})
             auth_req.context.update({"pii_traits": all_result_traits})
+            auth_req.context.update({"guardrail_name": guardrail_name})
             masked_traits = {}
             non_authz_scan_timings_per_message = self.analyze_scan_messages(access_control_traits, all_result_traits,
                                                                             analyzer_result_map, auth_req, False,


### PR DESCRIPTION

## Change Description

Added changes to include guardrail_name in the request context to log it in the audit logs. This enhancement allows better audit filtering and helps identify which guardrail was applied to the authorize request

## Issue reference

This PR fixes issue #300 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required