### PR TITLE
paig_automation_fix: Refactored group management listing test to avoid duplicate intercepts

### DIFF
--- a/paig-server/automation/cypress/e2e/account/user_management_groups_test.cy.js
+++ b/paig-server/automation/cypress/e2e/account/user_management_groups_test.cy.js
@@ -247,34 +247,41 @@ describe("Test User Management page for groups tab", () => {
         });
     }
 
-    it.skip("should verify groups management listing", () => {
+    it("should verify groups management listing", () => {
+        let newGroups = false;
         cy.intercept('GET', '/account-service/api/groups?page=0&size=15&sort=createTime,desc').as('getGroups');
         cy.get('[data-testid="header-refresh-btn"]').click();
+        let content = null;
         cy.wait('@getGroups').then((interception) => {
-            const { content } = interception.response.body;
+            content = interception.response.body;
+            content = content.content;
             if (content.length === 0) {
+                newGroups = true
                 // If no groups exist, create a couple of groups to start the test cases
                 const group1Name = generateUniqueName("TestGroup");
                 const group1Description = commonUtils.generateRandomSentence(10, 5);
                 createNewGroup(group1Name, group1Description);
                 cy.get('[data-testid="custom-dialog"]').should('not.exist');
-
                 const group2Name = generateUniqueName("TestGroup");
                 const group2Description = commonUtils.generateRandomSentence(10, 5);;
                 createNewGroup(group2Name, group2Description);
                 cy.get('[data-testid="custom-dialog"]').should('not.exist');
-            }
-            cy.wait(3000);
-            cy.get('[data-testid="header-refresh-btn"]').click();
-            // Proceed with verifying the groups management listing
-            cy.wait('@getGroups').then((interception) => {
-                const { content } = interception.response.body;
+            } else {
                 verifyUserManagementGroupsTable(content);
-            });
+            }
         });
+        if(newGroups) {
+            cy.intercept('GET', '/account-service/api/groups?page=0&size=15&sort=createTime,desc').as('getGroups1');
+            cy.get('[data-testid="header-refresh-btn"]').click();
+            cy.wait('@getGroups1').then((interception) => {
+                content = interception.response.body;
+                content = content.content;
+            });
+            verifyUserManagementGroupsTable(content);
+        }
     });
 
-    it.skip("should verify groups management listing on refresh", () => {
+    it("should verify groups management listing on refresh", () => {
         cy.intercept('GET', '/account-service/api/groups?page=0&size=15&sort=createTime,desc').as('getGroups');
         cy.get('[data-testid="header-refresh-btn"]').click();
 
@@ -284,7 +291,7 @@ describe("Test User Management page for groups tab", () => {
         });
     });
 
-    it.skip("should verify various search functionalities for groups", () => {
+    it("should verify various search functionalities for groups", () => {
         cy.intercept('GET', '/account-service/api/groups?page=0&size=15&sort=createTime,desc').as('getGroups');
         cy.intercept('GET', '/account-service/api/groups?size=15&sort=createTime,desc&name=*').as('searchGroups');
         cy.intercept('GET', '/account-service/api/groups?size=15&sort=createTime,desc').as('getSearchGroups');


### PR DESCRIPTION
## Change Description
Refactored group management listing test to avoid duplicate intercepts and ensure accurate validation post group creation

## Issue reference

This PR fixes issue #328

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [x] My code includes unit tests
- [x ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required