### PR TITLE
Updated readme with api key support for securechat and examples

### DIFF
--- a/paig-examples/python-openai-ai-app/README.md
+++ b/paig-examples/python-openai-ai-app/README.md
@@ -38,7 +38,7 @@ pip install openai==1.11.1 paig-client
 
        > **Note:** Once the API key is generated, it will not be shown again. Ensure you copy and securely store it immediately after generation.
 
-   - To initialize the **PAIG Shield** library in your SecureChat application, export the `PAIG_APP_API_KEY` as an environment variable:
+   - To initialize the **PAIG Shield** library in your application, export the `PAIG_APP_API_KEY` as an environment variable:
 
      ```bash
      export PAIG_APP_API_KEY=<<AI_APPLICATION_API_KEY>>

--- a/paig-examples/python-openai-ai-app/README.md
+++ b/paig-examples/python-openai-ai-app/README.md
@@ -26,13 +26,23 @@ To install the PAIG client, run the following command:
 pip install openai==1.11.1 paig-client
 ```
 
-## Step 3: Download the PAIG configuration file
-Download the PAIG configuration file from the PAIG server and save it under directory 'privacera'.
-```shell
-mkdir privacera
-```
+## Step 3: Create a new AI application and Generate an API key
+- To create a new application and generate an API key, follow these steps:
+     - Login to PAIG.
+     - Go to `Paig Navigator` → `AI Applications` and click the `CREATE APPLICATION` button at the top-right.
+     - A dialog box will open where you can enter the details of your application.
+     - Once the Application is created:
+       - Navigate to `Paig Navigator` → `AI Applications` and select the application for which you want to generate the API key.
+       - In the `API KEYS` tab, click the `GENERATE API KEY` button in the top-right corner.
+       - Provide a `Name` and `Description`, and set an `Expiry`, or select the `Max Validity (1 year)` checkbox to use the default expiry.
 
-***Note*** - If you have started server on 4545 port , PAIG default config can be downloaded using url http://127.0.0.1:4545/governance-service/api/ai/application/1/config/json/download
+       > **Note:** Once the API key is generated, it will not be shown again. Ensure you copy and securely store it immediately after generation.
+
+   - To initialize the **PAIG Shield** library in your SecureChat application, export the `PAIG_APP_API_KEY` as an environment variable:
+
+     ```bash
+     export PAIG_APP_API_KEY=<<AI_APPLICATION_API_KEY>>
+     ```
 
 ## Step 4: Set the OPENAI_API_KEY environment variable
 Set the OPENAI_API_KEY environment variable to your OpenAI API key.

--- a/paig-examples/python-openai-ai-app/ai-app.py
+++ b/paig-examples/python-openai-ai-app/ai-app.py
@@ -7,6 +7,8 @@ import uuid
 # Set the OPENAI_API_KEY environment variable or set it here
 openai_client = OpenAI()
 
+# Initialize PAIG Shield
+# Set the PAIG_APP_API_KEY environment variable or set it here in the setup method
 paig_shield_client.setup(frameworks=[])
 
 # Model

--- a/paig-examples/streamlit-openai-app/README.md
+++ b/paig-examples/streamlit-openai-app/README.md
@@ -17,13 +17,25 @@ chmod +x install.sh
 ./install.sh
 ```
 
-## Configuration
+## Create a new AI application and Generate an API key
+- To create a new application and generate an API key, follow these steps:
+     - Login to PAIG.
+     - Go to `Paig Navigator` → `AI Applications` and click the `CREATE APPLICATION` button at the top-right.
+     - A dialog box will open where you can enter the details of your application.
+     - Once the Application is created:
+       - Navigate to `Paig Navigator` → `AI Applications` and select the application for which you want to generate the API key.
+       - In the `API KEYS` tab, click the `GENERATE API KEY` button in the top-right corner.
+       - Provide a `Name` and `Description`, and set an `Expiry`, or select the `Max Validity (1 year)` checkbox to use the default expiry.
 
-Download the [Paig Shield Configuration](https://docs.paig.ai/integration/python-applications.html#downloading-privacera-shield-configuration-file) file, and place it in the `privacera` directory.
+       > **Note:** Once the API key is generated, it will not be shown again. Ensure you copy and securely store it immediately after generation.
 
-Once all the required packages are installed and configurations are set up, start the streamlit server within the virtual environment.
+   - To initialize the **PAIG Shield** library in your SecureChat application, export the `PAIG_APP_API_KEY` as an environment variable:
 
+     ```bash
+     export PAIG_APP_API_KEY=<<AI_APPLICATION_API_KEY>>
+     ```
 ```shell
 source venv/bin/activate
+export PAIG_APP_API_KEY=<<AI_APPLICATION_API_KEY>>
 streamlit run chatbot_simple.py
 ```

--- a/paig-examples/streamlit-openai-app/requirements.txt
+++ b/paig-examples/streamlit-openai-app/requirements.txt
@@ -1,4 +1,3 @@
 openai==1.51.0
-paig-client==0.0.1
-paig-common==0.0.1
 streamlit==1.39.0
+paig-client

--- a/paig-securechat/GET_STARTED.md
+++ b/paig-securechat/GET_STARTED.md
@@ -86,20 +86,25 @@
         ```
         _Note:_ You need to have already set up [`paig-server`](../paig-server/GET_STARTED.md) for this command to work
       
-   3. Log into PAIG url: http://127.0.0.1:4545 using `admin/welcome1` as default username and password.
-   4. To create a new application, go to `Application` > `AI Applications` and click the `CREATE APPLICATION` button on the right top. This will open a dialog box where you can enter the details of the application. 
-   5. Once the application is created, Navigate to Application -> AI Applications and select the application you want to download the configuration file for. 
-   6. Click on the `DOWNLOAD APP CONFIG` button from the right top to download the configuration file.
-   7. Copy the downloaded configuration file to the `custom-configs/privacera-shield-config.json`.<br>
-      Create `custom-configs` folder under `paig-securechat/web-server/src/paig_securechat` directory.
+   2. Log into PAIG url: http://127.0.0.1:4545 using `admin/welcome1` as default username and password.
+   3. To create a new application, go to `Application` > `AI Applications` and click the `CREATE APPLICATION` button on the right top. This will open a dialog box where you can enter the details of the application. 
+   4. Once the Application is created, 
+      - Navigate to `Paig Navigator` -> `AI Applications` and select the application for which you want to generate the api key. 
+      - In the `API KEYS` tab, click the `GENERATE API KEY` button in the top-right corner to generate an API key. 
+      - Provide a `Name` and `Description`, along with a `Expiry`, or select the `Max Validity (1 year)` checkbox to set default expiry.
       
-      ```bash
-      cd paig-securechat/web-server/src/paig_securechat
-      mkdir -p custom-configs
-      cp <path to privacera-shield-app-name-config.json> custom-configs/privacera-shield-config.json
-      ```
-
-   9. Start the PAIG SecureChat web server
+        > **Note:** Once the API key is generated, it will not be shown again. Ensure you copy and securely store it immediately after generation.
+   5. To initialize the PAIG Shield library in your AI application, export the __PAIG_APP_API_KEY__ as an environment variable.
+        ```shell
+        export PAIG_APP_API_KEY=<<AI_APPLICATION_API_KEY>>
+        ``` 
+      **OR**<br>
+      Create a file called `paig.key` in the `custom-configs` folder and save the AI Application API key in the file.
+        ```bash
+        echo "<<AI_APPLICATION_API_KEY>>" > > custom-configs/paig.key
+        ```
+   
+   6. Start the PAIG SecureChat web server
 
       ```bash
        python __main__.py run --host <host> --port <port> --debug True|False --config_path <path to config folder>

--- a/paig-securechat/GET_STARTED.md
+++ b/paig-securechat/GET_STARTED.md
@@ -101,7 +101,8 @@
       **OR**<br>
       Create a file called `paig.key` in the `custom-configs` folder and save the AI Application API key in the file.
         ```bash
-        echo "<<AI_APPLICATION_API_KEY>>" > > custom-configs/paig.key
+        mkdir -p custom-configs
+        echo "<<AI_APPLICATION_API_KEY>>" > custom-configs/paig.key
         ```
    
    6. Start the PAIG SecureChat web server

--- a/paig-securechat/web-server/README.md
+++ b/paig-securechat/web-server/README.md
@@ -59,7 +59,7 @@ Secure Chat provides a web interface to interact with the chat bot. It is a Reac
          1. Navigate to **Paig Navigator** -> **AI Applications** and select the application for which you want to generate the api key. 
          2. In the **API KEYS** tab, click the **GENERATE API KEY** button in the top-right corner to generate an API key. 
          3. Provide a **Name** and **Description**, along with a **Expiry**, or select the **Max Validity (1 year)** checkbox to set default expiry.
-         __Note__:- Once the Api Key is generated, it will not be displayed again. Ensure you copy and securely store it immediately after generation.
+         __Note__:- Once the API Key is generated, it will not be displayed again. Ensure you copy and securely store it immediately after generation.
    5. To initialize the PAIG Shield library in your AI application, export the __PAIG_APP_API_KEY__ as an environment variable.
         ```shell
         export PAIG_APP_API_KEY=<<AI_APPLICATION_API_KEY>>
@@ -67,7 +67,8 @@ Secure Chat provides a web interface to interact with the chat bot. It is a Reac
       **OR**<br>
       Create a file called `paig.key` in the `custom-configs` folder and save the AI Application API key in the file.
         ```bash
-        echo "<<AI_APPLICATION_API_KEY>>" > > custom-configs/paig.key
+        mkdir -p custom-configs
+        echo "<<AI_APPLICATION_API_KEY>>" > custom-configs/paig.key
         ``` 
 
 8. Start PAIG SecureChat web server

--- a/paig-securechat/web-server/README.md
+++ b/paig-securechat/web-server/README.md
@@ -55,17 +55,22 @@ Secure Chat provides a web interface to interact with the chat bot. It is a Reac
         ```
    2. Log into PAIG url: http://127.0.0.1:4545 using `admin/welcome1` as default username and password.
    3. To create a new application, go to `Paig Navigator` > `AI Applications` and click the `CREATE APPLICATION` button on the right top. This will open a dialog box where you can enter the details of the application. 
-   4. Once the application is created, Navigate to Application -> AI Applications and select the application you want to download the configuration file for. 
-   5. Click on the `DOWNLOAD APP CONFIG` button from the right top to download the configuration file. 
+   4. Once the Application is created, 
+         1. Navigate to **Paig Navigator** -> **AI Applications** and select the application for which you want to generate the api key. 
+         2. In the **API KEYS** tab, click the **GENERATE API KEY** button in the top-right corner to generate an API key. 
+         3. Provide a **Name** and **Description**, along with a **Expiry**, or select the **Max Validity (1 year)** checkbox to set default expiry.
+         __Note__:- Once the Api Key is generated, it will not be displayed again. Ensure you copy and securely store it immediately after generation.
+   5. To initialize the PAIG Shield library in your AI application, export the __PAIG_APP_API_KEY__ as an environment variable.
+        ```shell
+        export PAIG_APP_API_KEY=<<AI_APPLICATION_API_KEY>>
+        ``` 
+      **OR**<br>
+      Create a file called `paig.key` in the `custom-configs` folder and save the AI Application API key in the file.
+        ```bash
+        echo "<<AI_APPLICATION_API_KEY>>" > > custom-configs/paig.key
+        ``` 
 
-8. Copy the downloaded configuration file to the `custom-configs/privacera-shield-config.json`.
-   <br> Create `custom-configs` folder under `paig-securechat/web-server/src/paig_securechat` directory.
-   ```bash
-   mkdir -p custom-configs
-   cp <path to privacera-shield-app-name-config.json> custom-configs/privacera-shield-config.json
-   ```
-
-9. Start PAIG SecureChat web server
+8. Start PAIG SecureChat web server
    ```bash
     python __main__.py run --host <host> --port <port> --debug True|False --config_path <path to config folder> --openai_api_key <openai api key>
    ```
@@ -78,8 +83,8 @@ Secure Chat provides a web interface to interact with the chat bot. It is a Reac
     python __main__.py run --disable_paig_shield_plugin True
    ```
    
-10. Web server configuration can be found in the configs. Please refer to below [Configuration](#configuration) section for more details. 
-11. In development mode, the swagger api server will be available at http://localhost:<_port_>/docs
+9. Web server configuration can be found in the configs. Please refer to below [Configuration](#configuration) section for more details. 
+10. In development mode, the swagger api server will be available at http://localhost:<_port_>/docs
 
 ### Steps to run the development web UI server
 [How to use Secure Chat Web UI Server](../web-ui/README.md)

--- a/paig-securechat/web-server/src/README.md
+++ b/paig-securechat/web-server/src/README.md
@@ -20,12 +20,33 @@ pip install paig_securechat
 
 ## Usage <a name="usage"></a>
 PAIG Secure chat can be used in following ways:
-Before starting the securechat , please download your PAIG Shield Config file.Then run the following command to copy file to desired destination.
-```bash
-mkdir -p custom-configs
-cp <path to privacera-shield-app-name-config.json> custom-configs/privacera-shield-config.json
-``` 
-1. **Run as a service:** You can simply run the secure chat as a service by running following command:
+1. Before starting the securechat, you need to create a PAIG application and generate an API key for the application.
+   - To create a new application and generate an API key, follow these steps:
+     
+     - Login to PAIG.
+     - Go to `Paig Navigator` → `AI Applications` and click the `CREATE APPLICATION` button at the top-right.
+     - A dialog box will open where you can enter the details of your application.
+     - Once the Application is created:
+       
+       - Navigate to `Paig Navigator` → `AI Applications` and select the application for which you want to generate the API key.
+       - In the `API KEYS` tab, click the `GENERATE API KEY` button in the top-right corner.
+       - Provide a `Name` and `Description`, and set an `Expiry`, or select the `Max Validity (1 year)` checkbox to use the default expiry.
+
+       > **Note:** Once the API key is generated, it will not be shown again. Ensure you copy and securely store it immediately after generation.
+
+   - To initialize the **PAIG Shield** library in your SecureChat application, export the `PAIG_APP_API_KEY` as an environment variable:
+
+     ```bash
+     export PAIG_APP_API_KEY=<<AI_APPLICATION_API_KEY>>
+     ```
+
+     **OR**  
+     Create a file called `paig.key` in the `custom-configs` folder and save the AI Application API key in it:
+
+     ```bash
+     echo "<<AI_APPLICATION_API_KEY>>" > custom-configs/paig.key
+     ```
+2. **Run as a service:** You can simply run the secure chat as a service by running following command:
  ```bash
 paig_securechat run
  ```
@@ -37,7 +58,7 @@ Example:
 ```bash
 paig_securechat run --port 2324 --host 0.0.0.0 --openai_api_key <API_KEY> 
 ```
-2. **Run as a library:** You can run PAIG Secure chat in background by importing the library in your python code.
+3. **Run as a library:** You can run PAIG Secure chat in background by importing the library in your python code.
 Please run help command to see all available options you can pass while calling launch_app method.
 ```python
 from paig_securechat import launcher


### PR DESCRIPTION
## Change Description

This PR updates various documentation files to include instructions for generating and using API keys in PAIG SecureChat and related example applications.

Added step-by-step instructions for creating a PAIG application and generating an API key.
Updated environment variable setup instructions for initializing the PAIG Shield library.
Revised documentation and examples in multiple READMEs and sample code files.

## Issue reference

This PR fixes issue #75

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required