### PR TITLE
Add validation for metadata value

### DIFF
--- a/paig-server/backend/paig/api/governance/services/metadata_value_service.py
+++ b/paig-server/backend/paig/api/governance/services/metadata_value_service.py
@@ -90,10 +90,10 @@ class MetadataValueRequestValidator:
             value (str): The value of the Metadata Value.
         """
         if value is None:
-            raise BadRequestException("Attribute'metadataValue is required.")
+            raise BadRequestException("Attribute 'metadataValue' is required.")
 
         if isinstance(value, str) and value.strip() == "":
-            raise BadRequestException("Attribute'metadataValue cannot be empty or whitespace.")
+            raise BadRequestException("Attribute 'metadataValue' cannot be empty or whitespace.")
 
         validate_string_data(value, "Metadata attribute value", required=False, max_length=4000)
 

--- a/paig-server/backend/paig/api/governance/services/metadata_value_service.py
+++ b/paig-server/backend/paig/api/governance/services/metadata_value_service.py
@@ -3,7 +3,7 @@ from typing import List
 from core.controllers.base_controller import BaseController
 from core.controllers.paginated_response import Pageable
 from core.exceptions import BadRequestException
-from core.exceptions.error_messages_parser import (get_error_message, ERROR_RESOURCE_ALREADY_EXISTS)
+from core.exceptions.error_messages_parser import get_error_message, ERROR_RESOURCE_ALREADY_EXISTS
 from core.utils import validate_id, validate_string_data, SingletonDepends
 from api.governance.api_schemas.metadata_value import MetadataValueView, MetadataValueFilter
 from api.governance.database.db_models.metadata_value_model import VectorDBMetaDataValueModel
@@ -89,6 +89,12 @@ class MetadataValueRequestValidator:
         Args:
             value (str): The value of the Metadata Value.
         """
+        if value is None:
+            raise BadRequestException("Attribute'metadataValue is required.")
+
+        if isinstance(value, str) and value.strip() == "":
+            raise BadRequestException("Attribute'metadataValue cannot be empty or whitespace.")
+
         validate_string_data(value, "Metadata attribute value", required=False, max_length=4000)
 
     async def get_metadata_attr_by_values(self, metadata_attr: MetadataValueView):

--- a/paig-server/backend/paig/tests/api/governance/services/test_metadata_value_service.py
+++ b/paig-server/backend/paig/tests/api/governance/services/test_metadata_value_service.py
@@ -1,0 +1,23 @@
+
+import pytest
+from core.exceptions.base import BadRequestException
+from api.governance.services.metadata_value_service import MetadataValueRequestValidator
+
+validator = MetadataValueRequestValidator()
+
+@pytest.mark.parametrize("invalid_value, expected_message", [
+    (None, "Attribute 'metadataValue' is required"),
+    ("", "Attribute 'metadataValue' cannot be empty or whitespace"),
+    ("   ", "Attribute 'metadataValue' cannot be empty or whitespace"),
+])
+def test_validate_metadata_attr_value_invalid(invalid_value, expected_message):
+    with pytest.raises(BadRequestException) as exc_info:
+        validator.validate_metadata_attr_value(invalid_value)
+
+    assert expected_message in str(exc_info.value)
+
+def test_validate_metadata_attr_value_valid():
+    try:
+        validator.validate_metadata_attr_value("ValidValue")
+    except Exception:
+        pytest.fail("validate_metadata_attr_value raised an exception unexpectedly!")


### PR DESCRIPTION
## Change Description


Raised a BadRequestException if metadataValue is None.

Raised a BadRequestException if metadataValue is an empty or whitespace-only string.

This ensures that invalid or blank metadataValue inputs are rejected 


This PR fixes issue #312 

## Checklist

When metadataValue is None → received BadRequestException as expected.

When metadataValue is an empty string ("") → received BadRequestException.

When metadataValue is only whitespace (" ") → received BadRequestException.