### PR TITLE
Update evaluator, prompt utils, default config, and eval service

### DIFF
--- a/paig-evaluation/paig_evaluation/paig_evaluator.py
+++ b/paig-evaluation/paig_evaluation/paig_evaluator.py
@@ -180,3 +180,6 @@ class PAIGEvaluator:
             response['message'] = str(e)
         finally:
             return response
+
+
+init_config = eval_init_config

--- a/paig-evaluation/paig_evaluation/promptfoo_utils.py
+++ b/paig-evaluation/paig_evaluation/promptfoo_utils.py
@@ -329,12 +329,13 @@ def validate_evaluate_request_params(paig_eval_id, generated_prompts, base_promp
     return True, ""
 
 
-def suggest_promptfoo_redteam_plugins_with_openai(purpose: str) -> Dict | str:
+def suggest_promptfoo_redteam_plugins_with_openai(purpose: str, model: str = "gpt-4") -> Dict | str:
     """
     Suggests plugins to test security vulnerabilities based on the purpose of the application using OpenAI.
 
     Args:
         purpose (str): The purpose of the application.
+        model (str): The OpenAI model to use. Default is "gpt-4".
 
     Returns:
         List[Dict[str, str]] | str: The list of suggested plugins with descriptions or an error message.
@@ -369,7 +370,7 @@ def suggest_promptfoo_redteam_plugins_with_openai(purpose: str) -> Dict | str:
 
     try:
         response = openai.chat.completions.create(
-            model="gpt-4",
+            model=model,
             messages=[
                 {"role": "system", "content": "You are an AI security expert."},
                 {"role": "user", "content": prompt}

--- a/paig-server/backend/paig/conf/default_config.yaml
+++ b/paig-server/backend/paig/conf/default_config.yaml
@@ -26,6 +26,10 @@ authz:
       get_vector_db_details: 60
       get_vector_db_policies: 3
 
+llm:
+  model: 
+
+
 
 # disable_remote_eval_plugins: "false"
 # max_eval_concurrent_limit: 2


### PR DESCRIPTION
## Change Description

Describe your changes

## Issue reference

This PR fixes issue #397 

 printed the log — it first tries to fetch the value from the config, and if it's not provided, it falls back to the default. 
![testgpt2](https://github.com/user-attachments/assets/d5e22c96-de97-4495-a68e-80460402f068)
![testgpt1](https://github.com/user-attachments/assets/57b67298-8ade-4dd3-9d0e-dc4987509ac1)
