### PR TITLE
Fix for GR details sync b/w audit context and test input screen

### DIFF
--- a/paig-server/backend/paig/api/shield/scanners/PAIGPIIGuardrailScanner.py
+++ b/paig-server/backend/paig/api/shield/scanners/PAIGPIIGuardrailScanner.py
@@ -43,11 +43,12 @@ class PAIGPIIGuardrailScanner(Scanner):
         sensitive_data_config = self.get_property("sensitive_data_config")
 
         from api.shield.services.guardrail_service import paig_pii_guardrail_evaluation
-        deny_policies_list , redact_policies_dict = paig_pii_guardrail_evaluation(sensitive_data_config, pii_traits)
+        deny_policies_list , redact_policies_dict, allow_policies_list = paig_pii_guardrail_evaluation(sensitive_data_config, pii_traits)
 
         if len(deny_policies_list) > 0:
             return ScannerResult(traits=[], actions=["BLOCKED"], output_text=sensitive_data_config.get("response_message"))
         if len(redact_policies_dict) > 0:
             return ScannerResult(traits=[], actions=["ANONYMIZED"], masked_traits=redact_policies_dict)
-
+        if len(allow_policies_list) > 0:
+            return ScannerResult(traits=[], actions=["ALLOWED"], output_text=message)
         return ScannerResult(traits=[])


### PR DESCRIPTION
## Change Description

The GR details between test input screen api and audit context were not in sync. So made changes to align them.



## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [x] My code includes unit tests
- [x] All unit tests and lint checks pass locally
- [x] My PR contains documentation updates / additions if required