### PR TITLE
added env var for overriding api server url

### DIFF
--- a/paig-client/src/paig_client/core.py
+++ b/paig-client/src/paig_client/core.py
@@ -504,6 +504,8 @@ class PAIGApplication:
             is_self_hosted_shield_server = True
         else:
             self.shield_base_url = plugin_app_config_dict.get("apiServerUrl")
+            # Allow override from environment variable
+            self.shield_base_url = os.getenv("PAIG_API_SERVER_URL", self.shield_base_url)
 
         self.api_key = plugin_app_config_dict.get("apiKey")
         self.shield_server_key_id = plugin_app_config_dict.get("shieldServerKeyId")
@@ -587,6 +589,8 @@ class PAIGApplication:
                 )
 
             server_url = parts[1]
+            # Allow override from environment variable
+            server_url = os.getenv("PAIG_API_SERVER_URL", server_url)
             if server_url.startswith("https://") or server_url.startswith("http://"):
                 request_url = f"{server_url.rstrip('/')}/api/ai/application/config"
             else:


### PR DESCRIPTION
## Change Description
Provides an env variable to set for overriding the API server URL in the API key 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required