### PR TITLE
Issue-423: Fixed paginated response error for size zero and Added keep alive timeout for uvicorn to avoid connection reset by peer error

### DIFF
--- a/paig-server/backend/paig/__main__.py
+++ b/paig-server/backend/paig/__main__.py
@@ -155,12 +155,13 @@ def start_server(host, port, background, workers):
             host=host,
             port=port,
             workers=workers,
+            timeout_keep_alive=60
         )
     else:
         print('Starting PAIG Server in background mode')
         process = subprocess.Popen(
             [sys.executable, "-m", "uvicorn", "server:app", "--host", str(host), "--port", str(port),
-             "--workers", str(workers),
+             "--workers", str(workers), "--timeout-keep-alive", "60",
              "--app-dir", ROOT_DIR],
             start_new_session=True,
             stdout=subprocess.DEVNULL,

--- a/paig-server/backend/paig/core/controllers/paginated_response.py
+++ b/paig-server/backend/paig/core/controllers/paginated_response.py
@@ -59,7 +59,7 @@ def create_pageable_response(content: list, total_elements: int, page_number: in
     """
     return Pageable(
         content=content,
-        totalPages=(total_elements + size - 1) // size,
+        totalPages=((total_elements + size - 1) // size) if size else 0,
         totalElements=total_elements,
         last=(page_number + 1) * size >= total_elements,
         size=size,


### PR DESCRIPTION
## Change Description

1. Fixed paginated response error for size zero
2. Added keep-alive timeout for uvicorn to avoid connection reset by peer error

## Issue reference

This PR fixes issue #423 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required