### PR TITLE
Fix: return 400 Bad Request with specific message for missing fields

### DIFF
--- a/paig-server/backend/paig/api/shield/model/authorize_request.py
+++ b/paig-server/backend/paig/api/shield/model/authorize_request.py
@@ -1,5 +1,5 @@
 from typing import Dict
-from api.shield.utils.custom_exceptions import BadRequestException
+from fastapi.exceptions import RequestValidationError
 
 
 class AuthorizeRequest:
@@ -56,5 +56,12 @@ class AuthorizeRequest:
         """
         data = req_data.get(key)
         if not data:
-            raise BadRequestException(f"Missing {key} in request")
+            errors = [
+                {
+                    "loc": (key,),
+                    "msg": "field required",
+                    "type": "value_error.missing"
+                }
+            ]
+            raise RequestValidationError(errors=errors)
         return data


### PR DESCRIPTION
## Change Description

Replaced custom exception with RequestValidationError to properly handle missing fields and raise Error 400 in AuthorizeRequest.
 
## Issue reference

This PR fixes issue #318

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required