### PR TITLE
DOC: Remove repeated sentence in contributing guide

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -39,17 +39,6 @@ documented under the new version.
 Before sending your pull requests, make sure you do the following:
 - [Read the Code of Conduct](CODE_OF_CONDUCT.md)
 
-### 1. Create a fork of PAIG
-  You will need your own copy of paig to work on the code. Go to the paig project page and hit the Fork button. 
-  <br>You will want to clone your fork to your machine
-  
-  ```bash
-  git clone git@github.com:<username>/paig.git
-  cd paig
-  git remote add upstream git@github.com:privacera/paig.git
-  git fetch upstream
-  ```
-
 ### 1. Create a Fork of PAIG
 
 You will need your own copy of PAIG to work on the code. Go to the PAIG project page and hit the Fork button. Clone your


### PR DESCRIPTION
## Change Description

This pull request fixes a documentation issue in `CONTRIBUTING.md` where the section "Create a Fork of PAIG" was duplicated. The repeated instructions have been removed.

## Issue reference

This PR fixes issue #429 

## Checklist

- [x] I have reviewed the [contribution guidelines](https://github.com/privacera/paig/blob/main/docs/CONTRIBUTING.md)
- [ ] My code includes unit tests
- [ ] All unit tests and lint checks pass locally
- [ ] My PR contains documentation updates / additions if required