### PR TITLE
Added Enable or Disable Suggested Plugins Feature

### DIFF
--- a/paig-server/backend/paig/conf/default_config.yaml
+++ b/paig-server/backend/paig/conf/default_config.yaml
@@ -27,7 +27,7 @@ authz:
       get_vector_db_policies: 3
 
 
-# disable_remote_eval_plugins: "false"
+disable_remote_eval_plugins: "false"
 # target_application_connection_timeout: 60
 # max_eval_concurrent_limit: 2
 # eval_timeout_in_min: 3600

--- a/paig-server/backend/paig/conf/default_config.yaml
+++ b/paig-server/backend/paig/conf/default_config.yaml
@@ -27,7 +27,7 @@ authz:
       get_vector_db_policies: 3
 
 
-disable_remote_eval_plugins: "false"
+# disable_remote_eval_plugins: "false"
 # target_application_connection_timeout: 60
 # max_eval_concurrent_limit: 2
 # eval_timeout_in_min: 3600

--- a/paig-server/backend/paig/conf/default_config.yaml
+++ b/paig-server/backend/paig/conf/default_config.yaml
@@ -27,6 +27,7 @@ authz:
       get_vector_db_policies: 3
 
 
+# disable_plugin_suggestions: "false"
 # disable_remote_eval_plugins: "false"
 # target_application_connection_timeout: 60
 # max_eval_concurrent_limit: 2

--- a/paig-server/backend/paig/services/eval/paig_eval_service/services/eval_service.py
+++ b/paig-server/backend/paig/services/eval/paig_eval_service/services/eval_service.py
@@ -34,7 +34,7 @@ if config.get("disable_remote_eval_plugins", False):
 eval_init_config(email='promptfoo@paig.ai', plugin_file_path=config.get("eval_category_file", None))
 
 DISABLE_EVAL_CONCURRENT_LIMIT = str(config.get("disable_eval_concurrent_limit", "false")).lower() == "true"
-DISABLE_REMOTE_EVAL_PLUGINS = str(config.get("disable_remote_eval_plugins", "false")).lower() == "true"
+DISABLE_PLUGIN_SUGGESTIONS = str(config.get("disable_plugin_suggestions", "false")).lower() == "true"
 MAX_CONCURRENT_EVALS = config.get("max_eval_concurrent_limit", 2)
 EVAL_TIMEOUT = config.get("eval_timeout_in_min", 6*60) # 6 hours
 ENABLE_EVAL_VERBOSE = str(config.get("enable_eval_verbose", "false")).lower() == "true"
@@ -311,7 +311,7 @@ class EvaluationService:
     @staticmethod
     async def get_categories(purpose):
         resp = dict()
-        if not DISABLE_REMOTE_EVAL_PLUGINS:
+        if not DISABLE_PLUGIN_SUGGESTIONS:
             suggested_categories = get_suggested_plugins(purpose)
             if not isinstance(suggested_categories, dict):
                 raise BadRequestException('Invalid response received for for suggested categories')

--- a/paig-server/frontend/webapp/app/components/audits/evaluation/v_evaluation_categories_form.jsx
+++ b/paig-server/frontend/webapp/app/components/audits/evaluation/v_evaluation_categories_form.jsx
@@ -65,26 +65,33 @@ const VEvaluationCategories = observer(({ form, selectedCategories, showSuggeste
   const allCategoriesSelected = selectedCategories.length === filteredCategories.length;
   const someCategoriesSelected = selectedCategories.length > 0 && selectedCategories.length < filteredCategories.length;
   
+  // Check if suggested categories exist in the response
+  const hasSuggestedCategories = _vState.purposeResponse?.suggested_categories?.length > 0;
+  
   return (
     <Box component={Paper} elevation={0} p="15px">
       <Typography variant="h6" data-testid="header">
         Evaluation categories 
       </Typography>
       <p>Evaluation categories help you focus on specific aspects of model performance that align with your goals. These categories enable you to assess key areas like accuracy, fairness, safety, and relevance, ensuring the evaluation process is comprehensive and tailored to your needs. By selecting the relevant categories, you can ensure a well-rounded analysis that addresses your most important criteria.</p>
-      <Alert severity="info">
-        Categories and types are displayed based on the evaluation purpose in the previous step. To explore all available options, disable Suggested filters to override the filter.
-      </Alert>
-      <FormControlLabel
-        control={
-          <Switch 
-            color="primary" 
-            checked={showSuggested} 
-            onChange={handleToggle} 
+      {hasSuggestedCategories && (
+        <>
+          <Alert severity="info">
+            Categories and types are displayed based on the evaluation purpose in the previous step. To explore all available options, disable Suggested filters to override the filter.
+          </Alert>
+          <FormControlLabel
+            control={
+              <Switch 
+                color="primary" 
+                checked={showSuggested} 
+                onChange={handleToggle} 
+              />
+            }
+            label={<Typography variant="body1">Suggested filters</Typography>}
+            className="m-t-md m-b-md"
           />
-        }
-        label={<Typography variant="body1">Suggested filters</Typography>}
-        className="m-t-md m-b-md"
-      />
+        </>
+      )}
       {_vState.errorMsg && (
         <Grid container spacing={3} className="m-b-sm">
           <Grid item xs={12}>

--- a/paig-server/frontend/webapp/app/containers/audits/evaluation/c_evaluation_categories_form.jsx
+++ b/paig-server/frontend/webapp/app/containers/audits/evaluation/c_evaluation_categories_form.jsx
@@ -32,16 +32,9 @@ class CEvaluationCategoriesForm extends Component {
   }
 
   handleToggle = () => {
-    const { _vState } = this.props;
-    const evalCategories = _vState.purposeResponse;
-    
-    this.setState((prevState) => {
-      const showSuggested = !prevState.showSuggested;
-      // Keep the existing selections when toggling
-      return {
-        showSuggested
-      };
-    });
+    this.setState((prevState) => ({
+      showSuggested: !prevState.showSuggested,
+    }));
   };
 
   setSelectedCategories = (selectedCategories) => {

--- a/paig-server/frontend/webapp/app/containers/audits/evaluation/c_evaluation_categories_form.jsx
+++ b/paig-server/frontend/webapp/app/containers/audits/evaluation/c_evaluation_categories_form.jsx
@@ -14,29 +14,49 @@ class CEvaluationCategoriesForm extends Component {
   componentDidMount() {
     const { _vState } = this.props;
     const evalCategories = _vState.purposeResponse;
-    const suggestedCategories = evalCategories.suggested_categories.map((category) => category.Name);
-    this.props.form.refresh({ categories: suggestedCategories });
-    if (suggestedCategories.length === 0) {
-      this.setState({showSuggested: false})
+    const hasSuggestedCategories = evalCategories?.suggested_categories?.length > 0;
+    
+    if (hasSuggestedCategories) {
+      // If there are suggested categories, use them and select them by default
+      const categories = evalCategories.suggested_categories.map((category) => category.Name);
+      this.props.form.refresh({ categories });
+      this.setState({ selectedCategories: categories });
+    } else {
+      // If there are no suggested categories, don't select any by default
+      this.setState({ 
+        showSuggested: false,
+        selectedCategories: [] 
+      });
+      this.props.form.refresh({ categories: [] });
     }
-    this.setState({ selectedCategories: suggestedCategories });
   }
 
   handleToggle = () => {
-    this.setState((prevState) => ({
-      showSuggested: !prevState.showSuggested,
-    }));
+    const { _vState } = this.props;
+    const evalCategories = _vState.purposeResponse;
+    
+    this.setState((prevState) => {
+      const showSuggested = !prevState.showSuggested;
+      // Keep the existing selections when toggling
+      return {
+        showSuggested
+      };
+    });
   };
 
   setSelectedCategories = (selectedCategories) => {
     this.setState({ selectedCategories });
+    this.props.form.refresh({ categories: selectedCategories });
   };
 
   render() {
     const { selectedCategories, showSuggested } = this.state;
     const { _vState } = this.props;
     const evalCategories = _vState.purposeResponse;
-    const filteredCategories = showSuggested ? evalCategories.suggested_categories : evalCategories.all_categories;
+    // Only filter what categories to show, but maintain selections
+    const filteredCategories = showSuggested && evalCategories?.suggested_categories?.length > 0 ? 
+      evalCategories.suggested_categories : 
+      evalCategories.all_categories;
 
     return (
       <VEvaluationCategoriesForm


### PR DESCRIPTION
## Fix #374 - Enable or Disable Suggested Plugins Feature in Eval

**Changes**:
- Standardized config parsing using `DISABLE_REMOTE_EVAL_PLUGINS` constant in `eval_service.py`
- Updated frontend components to handle plugin states consistently
- Remains at default `false` value unless explicitly overriden

**Testing Performed**:
- [x] Config set to "true" (disable suggested plugins)
- [x] Config set to "false" (enable suggested plugins) 
- [x] Verified frontend UI reflects config state

**Issue Reference**:

This PR fixes Issue #374 

**Notes**:
