### PR TITLE
AI Application and Policy Count for Grafana

### DIFF
--- a/paig-server/backend/paig/api/governance/database/db_operations/ai_app_policy_repository.py
+++ b/paig-server/backend/paig/api/governance/database/db_operations/ai_app_policy_repository.py
@@ -50,3 +50,35 @@ class AIAppPolicyRepository(BaseOperations[AIApplicationPolicyModel]):
         query = query.filter(and_(*query_filters))
 
         return await self._all(query)
+    
+    async def count_all(self) -> int:
+        """
+        Count total AI application policies in the system.
+
+        This is defensive: different repository layers may return:
+         - (records, total_count)
+         - a list of records
+         - None
+        We handle all shapes and return an int.
+        """
+        result = await self.get_all({})  # ask repository for everything
+
+        if result is None:
+            return 0
+
+        # if repository returns a tuple like (records, total_count)
+        if isinstance(result, tuple):
+            if len(result) >= 2 and isinstance(result[1], int):
+                return result[1]
+            records = result[0]
+            return len(records) if records else 0
+
+        # if repository returns a list of records
+        if isinstance(result, list):
+            return len(result)
+
+        # fallback: try len(), otherwise return 0
+        try:
+            return len(result)
+        except Exception:
+            return 0

--- a/paig-server/backend/paig/api/governance/database/db_operations/ai_app_policy_repository.py
+++ b/paig-server/backend/paig/api/governance/database/db_operations/ai_app_policy_repository.py
@@ -2,6 +2,8 @@ from typing import List
 from sqlalchemy import or_, and_
 from core.factory.database_initiator import BaseOperations
 from api.governance.database.db_models.ai_app_policy_model import AIApplicationPolicyModel
+from core.db_session import session
+from sqlalchemy import select, func
 
 
 class AIAppPolicyRepository(BaseOperations[AIApplicationPolicyModel]):
@@ -53,32 +55,8 @@ class AIAppPolicyRepository(BaseOperations[AIApplicationPolicyModel]):
     
     async def count_all(self) -> int:
         """
-        Count total AI application policies in the system.
-
-        This is defensive: different repository layers may return:
-         - (records, total_count)
-         - a list of records
-         - None
-        We handle all shapes and return an int.
+        Count total AI application policies efficiently using SQL COUNT().
         """
-        result = await self.get_all({})  # ask repository for everything
-
-        if result is None:
-            return 0
-
-        # if repository returns a tuple like (records, total_count)
-        if isinstance(result, tuple):
-            if len(result) >= 2 and isinstance(result[1], int):
-                return result[1]
-            records = result[0]
-            return len(records) if records else 0
-
-        # if repository returns a list of records
-        if isinstance(result, list):
-            return len(result)
-
-        # fallback: try len(), otherwise return 0
-        try:
-            return len(result)
-        except Exception:
-            return 0
+        query = select(func.count()).select_from(self.model_class)  # SELECT COUNT(*) FROM ai_app_policy_model
+        result = await session.execute(query)  # use global session
+        return result.scalar_one()  # return the count directly

--- a/paig-server/backend/paig/api/governance/database/db_operations/ai_app_repository.py
+++ b/paig-server/backend/paig/api/governance/database/db_operations/ai_app_repository.py
@@ -5,6 +5,8 @@ from core.exceptions import NotFoundException
 from core.exceptions.error_messages_parser import get_error_message, ERROR_RESOURCE_NOT_FOUND
 from core.factory.database_initiator import BaseOperations
 from api.governance.database.db_models.ai_app_model import AIApplicationModel
+from core.db_session import session
+from sqlalchemy import select, func
 
 
 class AIAppRepository(BaseOperations[AIApplicationModel]):
@@ -55,27 +57,8 @@ class AIAppRepository(BaseOperations[AIApplicationModel]):
             return None
     async def count_all(self) -> int:
         """
-        Count total AI applications in the system.
-
-        Uses the repository's get_all() to avoid importing the session provider.
-        This is defensive: if get_all returns (records, total_count) or a list,
-        we handle both shapes.
+        Count total AI applications efficiently using SQL COUNT().
         """
-        result = await self.get_all({})  # ask repository for everything
-
-        # if repository returns a tuple like (records, total_count)
-        if isinstance(result, tuple):
-            if len(result) >= 2 and isinstance(result[1], int):
-                return result[1]
-            records = result[0]
-            return len(records) if records else 0
-
-        # if repository returns a list of records
-        if isinstance(result, list):
-            return len(result)
-
-        # fallback: try len(), otherwise return 0
-        try:
-            return len(result)
-        except Exception:
-            return 0
+        query = select(func.count()).select_from(self.model_class)  # SELECT COUNT(*)
+        result = await session.execute(query)  # use imported global session
+        return result.scalar_one()  # returns the count directly

--- a/paig-server/backend/paig/api/governance/database/db_operations/ai_app_repository.py
+++ b/paig-server/backend/paig/api/governance/database/db_operations/ai_app_repository.py
@@ -53,3 +53,29 @@ class AIAppRepository(BaseOperations[AIApplicationModel]):
             return await self.get_all({field: values}, apply_in_list_filter=True)
         except NoResultFound:
             return None
+    async def count_all(self) -> int:
+        """
+        Count total AI applications in the system.
+
+        Uses the repository's get_all() to avoid importing the session provider.
+        This is defensive: if get_all returns (records, total_count) or a list,
+        we handle both shapes.
+        """
+        result = await self.get_all({})  # ask repository for everything
+
+        # if repository returns a tuple like (records, total_count)
+        if isinstance(result, tuple):
+            if len(result) >= 2 and isinstance(result[1], int):
+                return result[1]
+            records = result[0]
+            return len(records) if records else 0
+
+        # if repository returns a list of records
+        if isinstance(result, list):
+            return len(result)
+
+        # fallback: try len(), otherwise return 0
+        try:
+            return len(result)
+        except Exception:
+            return 0

--- a/paig-server/backend/paig/api/governance/services/ai_app_policy_service.py
+++ b/paig-server/backend/paig/api/governance/services/ai_app_policy_service.py
@@ -252,6 +252,7 @@ class AIAppPolicyService(BaseController[AIApplicationPolicyModel, AIApplicationP
             AIAppPolicyRepository: The AI application repository.
         """
         return self.repository
+    
 
     async def list_ai_application_policies(self, app_policy_filter: AIApplicationPolicyFilter, page_number: int, size: int, sort: List[str]) -> Pageable:
         """
@@ -272,7 +273,14 @@ class AIAppPolicyService(BaseController[AIApplicationPolicyModel, AIApplicationP
             size=size,
             sort=sort
         )
-
+    async def get_ai_application_policy_count(self) -> int:
+        """
+        Fetch total number of AI application policies in the system via repository.count_all()
+        """
+        repository = self.get_repository()
+        return await repository.count_all()
+    
+    
     async def get_ai_application_policy_by_id(self, app_id: int, id: int) -> AIApplicationPolicyView:
         """
         Retrieve an AI application policy by its ID.

--- a/paig-server/backend/paig/api/governance/services/ai_app_service.py
+++ b/paig-server/backend/paig/api/governance/services/ai_app_service.py
@@ -238,6 +238,12 @@ class AIAppService(BaseController[AIApplicationModel, AIApplicationView]):
             size=size,
             sort=sort
         )
+    async def get_ai_application_count(self) -> int:
+        """
+        Fetch total number of AI applications in the system via repository.count_all()
+        """
+        repository = self.get_repository()
+        return await repository.count_all()
 
     async def list_ai_applications_by_vector_db(self, vector_db_name: str) -> List[AIApplicationView]:
         """

--- a/paig-server/backend/paig/routers.py
+++ b/paig-server/backend/paig/routers.py
@@ -1,4 +1,6 @@
 from fastapi import APIRouter, Depends
+from fastapi.responses import PlainTextResponse
+from prometheus_client import generate_latest, CONTENT_TYPE_LATEST
 
 from api.guardrails.routers import paig_guardrails_router
 from api.user.routers import user_router
@@ -14,6 +16,11 @@ from api.eval.routers import evaluation_router_paths
 from api.apikey.routers import api_key_router
 from core.security.authentication import get_auth_user
 from api.governance.routes.ai_app_config_download_router import ai_app_config_download_with_key_router
+from utils1.custom_metrics import ai_apps_total_gauge
+from api.governance.services.ai_app_service import AIAppService
+from utils1.custom_metrics import ai_app_policies_total_gauge
+from api.governance.services.ai_app_policy_service import AIAppPolicyService
+from core.utils import SingletonDepends
 
 router = APIRouter()
 
@@ -31,4 +38,26 @@ router.include_router(paig_guardrails_router, prefix="/guardrail-service/api", d
 router.include_router(api_key_router, prefix="/account-service/api/apikey", tags=["API Key"])
 router.include_router(ai_app_config_download_with_key_router, prefix="/api/ai/application/config", tags=["Governance with API Key"])
 
+@router.get("/metrics")
+async def metrics(
+    ai_app_service: AIAppService = Depends(SingletonDepends(AIAppService, called_inside_fastapi_depends=True)),
+    ai_app_policy_service: AIAppPolicyService = Depends(SingletonDepends(AIAppPolicyService, called_inside_fastapi_depends=True)),   
+):
+    """ Prometheus metrics endpoint """
+    try:
+        # get the latest AI application count and set the gauge
+        count = await ai_app_service.get_ai_application_count()
+        ai_apps_total_gauge.set(count)
+        try:
+            #get the latest AI application policy count and set the guage
+            policy_count = await ai_app_policy_service.get_ai_application_policy_count()
+            ai_app_policies_total_gauge.set(policy_count)
+        except Exception:
+            # don't break the whole endpoint if policy counting fails
+            pass
+        # return all metrics
+        return PlainTextResponse(generate_latest(), media_type=CONTENT_TYPE_LATEST)
+    except Exception as e:
+        # helpful error message for debugging
+        return PlainTextResponse(f"Metrics endpoint failed: {e}", status_code=500)
 __all__ = ["router"]

--- a/paig-server/backend/paig/utils1/custom_metrics.py
+++ b/paig-server/backend/paig/utils1/custom_metrics.py
@@ -1,0 +1,11 @@
+# utils/custom_metrics.py
+from prometheus_client import Gauge
+ai_apps_total_gauge = Gauge(
+    "paig_ai_applications_total",
+    "Total number of AI applications in the system"
+)
+# utils/custom_metrics.py
+ai_app_policies_total_gauge = Gauge(
+    "paig_ai_application_policies_total",
+    "Total number of AI application policies in the system"
+)


### PR DESCRIPTION

<img width="1140" height="620" alt="Screenshot 2025-09-29 at 1 24 45 PM" src="https://github.com/user-attachments/assets/df2df32e-cdad-409b-a3f1-1e1fd3e7c382" />

## Description
This PR introduces functionality to expose the total count of AI applications and AI application policies, enabling real-time monitoring through Grafana via Prometheus.


## Changes

- Added get_ai_application_count() in AIAppService to fetch the total number of AI applications.
- Added get_ai_application_policy_count() in AIAppPolicyService to fetch the total number of AI application policies.
- Implemented count_all() in AIAppRepository and AIAppPolicyRepository to reliably handle different repository return types (list, tuple, or None).
- These counts can be scraped by Prometheus and visualized in Grafana dashboards for system monitoring.

## Purpose:

- To enable monitoring of AI applications and their associated policies in the system.
- Provides a single source of truth for total counts to support dashboards and alerting.